### PR TITLE
Merge default options with specified options

### DIFF
--- a/beaker-puppet_install_helper.gemspec
+++ b/beaker-puppet_install_helper.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "beaker-puppet_install_helper"
-  s.version     = '0.1.2'
+  s.version     = '0.1.3'
   s.authors     = ["Puppetlabs"]
   s.email       = ["hunter@puppetlabs.com"]
   s.homepage    = "https://github.com/puppetlabs/beaker-puppet_install_helper"

--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -26,12 +26,12 @@ module Beaker::PuppetInstallHelper
     case type
     when "pe"
       # This will skip hosts that are not supported
-      install_pe_on(Array(hosts),{"pe_ver" => version})
+      install_pe_on(Array(hosts),options.merge({"pe_ver" => version}))
     when "foss"
-      opts = {
+      opts = options.merge({
         :version        => version,
         :default_action => "gem_install",
-      }
+      })
 
       install_puppet_on(hosts, opts)
       # XXX install_puppet_on() will only add_aio_defaults_on when the nodeset
@@ -56,7 +56,7 @@ module Beaker::PuppetInstallHelper
       end
     when "agent"
       # This will fail on hosts that are not supported; use foss and specify a 4.x version instead
-      install_puppet_agent_on(hosts, {:version => version})
+      install_puppet_agent_on(hosts,options.merge({:version => version}))
       # XXX install_puppet_agent_on() will only add_aio_defaults_on when the
       # nodeset type == 'aio', but we don't want to depend on that.
       add_aio_defaults_on(hosts)

--- a/spec/unit/beaker/puppet_install_helper_spec.rb
+++ b/spec/unit/beaker/puppet_install_helper_spec.rb
@@ -14,6 +14,7 @@ describe 'beaker::puppet_install_helper' do
     [foss_host, pe_host]
   end
   before :each do
+    allow(subject).to receive(:options).and_return({})
     allow(subject).to receive(:on)
     allow(subject).to receive(:fact_on)
   end


### PR DESCRIPTION
Beaker does not consistently merge the default options with passed
options and so will lose all options other than the passed ones unless
we merge for it.
