### PR TITLE
Configure defaults if BEAKER_provision == no

### DIFF
--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -9,10 +9,21 @@ module Beaker::PuppetInstallHelper
   # - Type defaults to PE for PE nodes, and foss otherwise.
   # - Version will default to the latest 3x foss/pe package, depending on type
   def run_puppet_install_helper_on(hosts,type_arg=find_install_type,version=ENV["PUPPET_VERSION"])
-    # Short circuit based on rspec-system and beaker variables
-    return if ENV["RS_PROVISION"] == "no" or ENV["BEAKER_provision"] == "no"
 
     type = type_arg || find_install_type
+
+    # Short circuit based on rspec-system and beaker variables
+    if ENV["RS_PROVISION"] == "no" or ENV["BEAKER_provision"] == "no"
+      Array(hosts).each do |host|
+        case type
+        when "pe"
+          configure_pe_defaults_on(host)
+        when /foss|agent/
+          configure_foss_defaults_on(host)
+        end
+      end
+      return
+    end
 
     # Example environment variables to be read:
     # PUPPET_VERSION=3.8.1 <-- for foss/pe/gem


### PR DESCRIPTION
If BEAKER_provision is set to 'no', puppet_install_helper aborts
quickly because there is no need to reinstall puppet. However, the
install_puppet method not only installs puppet, but also sets values in
the Host objects in the hosts array[1]. This is a problem because the
spec_helper_acceptance.rb file within a module needs to have the value
for the 'distmoduledir' key in the host it is configuring in order for
the puppet_module_install command to copy modules into the correct
directory. If it is not set, it will default to empty and try to copy
modules into '/'[2]. This patch adds logic to perform the correct
configure_*_defaults method if BEAKER_provision is set to 'no' before
aborting.

[1] https://github.com/puppetlabs/beaker/blob/master/lib/beaker/dsl/install_utils/foss_utils.rb#L414
[2] http://logs.openstack.org/49/196249/3/check/gate-puppet-cinder-puppet-beaker-rspec-upgrade-dsvm-trusty/54f4f3a/console.html#_2015-06-30_02_32_24_230
