### PR TITLE
Add Solaris for extra certs

### DIFF
--- a/lib/beaker/ca_cert_helper.rb
+++ b/lib/beaker/ca_cert_helper.rb
@@ -15,11 +15,13 @@ module Beaker::CaCertHelper
   #
   ##
   def install_ca_certs_on(hosts)
-    Array[hosts].each do |host|
+    [hosts].flatten.each do |host|
       get_cert_hash.each do |cert_name, ca|
         create_cert_on_host(host, cert_name, ca)
         if host['platform'] =~ /windows/i
           add_windows_cert host, cert_name
+        elsif host['platform'] =~ /solaris/i
+          add_solaris_cert host, cert_name
         end
       end
     end
@@ -38,6 +40,14 @@ module Beaker::CaCertHelper
   ##
   def add_windows_cert(host, ca_filename)
     on host, "cmd /c certutil -v -addstore Root `cygpath -w #{ca_filename}`"
+  end
+
+  ##
+  # Install cert, assumes cygwin currently
+  ##
+  def add_solaris_cert(host, ca_filename)
+    on host, "echo '# #{ca_filename}' >> /opt/puppet/ssl/cert.pem"
+    on host, "cat #{ca_filename} >> /opt/puppet/ssl/cert.pem"
   end
 
   ##

--- a/spec/unit/beaker/ca_cert_helper_spec.rb
+++ b/spec/unit/beaker/ca_cert_helper_spec.rb
@@ -22,6 +22,16 @@ describe 'beaker::ca_cert_helper' do
       expect(subject).to receive(:create_cert_on_host).with(w2k3, 'usertrust-network.pem', 'my user trust cert')
       subject.install_ca_certs_on w2k3
     end
+
+    it "solaris 11 node" do
+      sol = {"platform" => 'solaris-11-x86_64', 'distmoduledir' => '/dne', 'hieraconf' => '/dne'}
+
+      expect(subject).to receive(:add_solaris_cert).with(sol, 'geotrustglobal.pem')
+      expect(subject).to receive(:create_cert_on_host).with(sol, 'geotrustglobal.pem', 'my cert string')
+      expect(subject).to receive(:add_solaris_cert).with(sol, 'usertrust-network.pem')
+      expect(subject).to receive(:create_cert_on_host).with(sol, 'usertrust-network.pem', 'my user trust cert')
+      subject.install_ca_certs_on sol
+    end
   end
 
   describe 'add_windows_cert' do
@@ -29,6 +39,15 @@ describe 'beaker::ca_cert_helper' do
       host = {"platform" => 'windows-2003r2-64', 'distmoduledir' => '/dne', 'hieraconf' => '/dne'}
       expect(subject).to receive(:on).with(host, 'cmd /c certutil -v -addstore Root `cygpath -w geotrustglobal.pem`')
       subject.add_windows_cert host, 'geotrustglobal.pem'
+    }
+  end
+
+  describe 'add_solaris_cert' do
+    it {
+      host = {"platform" => 'solaris-11-x86_64', 'distmoduledir' => '/dne', 'hieraconf' => '/dne'}
+      expect(subject).to receive(:on).with(host, 'echo \'# geotrustglobal.pem\' >> /opt/puppet/ssl/cert.pem')
+      expect(subject).to receive(:on).with(host, 'cat geotrustglobal.pem >> /opt/puppet/ssl/cert.pem')
+      subject.add_solaris_cert host, 'geotrustglobal.pem'
     }
   end
 


### PR DESCRIPTION
Puppet Enterprise 3.8 on Solaris only reads certs from
/opt/puppet/ssl/cert.pem
