### PR TITLE
(maint) loosen beaker version dependency

### DIFF
--- a/beaker-puppet_install_helper.gemspec
+++ b/beaker-puppet_install_helper.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker', '~> 2.0'
+  s.add_runtime_dependency 'beaker', '>= 2.0'
 end


### PR DESCRIPTION
This change allows for beaker 3.0.0 to be utilized for testing.
