### PR TITLE
(MODULES-4230) Add install puppet-agent from development repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ The way to use this is to declare either `run_puppet_install_helper()` or `run_p
 
 The best way is explicitly set `PUPPET_INSTALL_TYPE` and `PUPPET_INSTALL_VERSION` to what you want. It'll probably do what you expect.
 
+#### Installing a puppet-agent package from a development repository
+
+In order to use a custom, or unreleased, puppet-agent package set the following environment variables"
+- `PUPPET_INSTALL_TYPE=agent`
+- `PUPPET_AGENT_SHA` is the longform commit SHA used when building the puppet-agent package, for example `PUPPET_AGENT_SHA=18d31fd5ed41abb276398201f84a4347e0fc7092`.  This is required to be set in order to use a development puppet-agent package
+- `PUPPET_AGENT_SUITE_VERSION` is the version of the puppet-agent package, for example `PUPPET_AGENT_SUITE_VERSION="1.8.2.350.g18d31fd`.  This is optional, and will default to `PUPPET_AGENT_SHA` if not set
+
 ### `install_ca_certs`
 
 Install Certificate Authority Certs on Windows and OSX for Geotrust, User Trust Network, and Equifax

--- a/spec/unit/beaker/puppet_install_helper_spec.rb
+++ b/spec/unit/beaker/puppet_install_helper_spec.rb
@@ -26,6 +26,8 @@ describe 'beaker::puppet_install_helper' do
     ENV.delete("PUPPET_VERSION")
     ENV.delete("PUPPET_INSTALL_VERSION")
     ENV.delete("PUPPET_INSTALL_TYPE")
+    ENV.delete("PUPPET_AGENT_SHA")
+    ENV.delete("PUPPET_AGENT_SUITE_VERSION")
   end
   describe '#run_puppet_install_helper' do
     before :each do
@@ -124,6 +126,25 @@ describe 'beaker::puppet_install_helper' do
         ENV["PUPPET_INSTALL_TYPE"] = "agent"
         ENV["PUPPET_INSTALL_VERSION"] = "1.1.0"
         expect(subject).to receive(:install_puppet_agent_on).with(hosts,{:version => "1.1.0"})
+        expect(subject).to receive(:add_aio_defaults_on).with(hosts)
+        expect(subject).to receive(:add_puppet_paths_on).with(hosts)
+        subject.run_puppet_install_helper_on(hosts)
+      end
+    end
+    context "for puppet-agent development repo" do
+      before :each do
+        ENV["PUPPET_INSTALL_TYPE"] = "agent"
+        ENV["PUPPET_AGENT_SHA"] = 'abc123'
+      end
+      it "uses a development repo" do
+        expect(subject).to receive(:install_puppet_agent_dev_repo_on).with(hosts,{:puppet_collection=>"PC1", :puppet_agent_sha=>"abc123", :puppet_agent_version=>"abc123"})
+        expect(subject).to receive(:add_aio_defaults_on).with(hosts)
+        expect(subject).to receive(:add_puppet_paths_on).with(hosts)
+        subject.run_puppet_install_helper_on(hosts)
+      end
+      it "uses a development repo with suite version" do
+        ENV["PUPPET_AGENT_SUITE_VERSION"] = '1.0.0.0.gabc123'
+        expect(subject).to receive(:install_puppet_agent_dev_repo_on).with(hosts,{:puppet_collection=>"PC1", :puppet_agent_sha=>"abc123", :puppet_agent_version=>"1.0.0.0.gabc123"})
         expect(subject).to receive(:add_aio_defaults_on).with(hosts)
         expect(subject).to receive(:add_puppet_paths_on).with(hosts)
         subject.run_puppet_install_helper_on(hosts)


### PR DESCRIPTION
Previously the puppet-agent package could only be installed from released repo
or distribution points.  This meant that pre-released puppet-agent packages
could not be used if using this helper.  This commit adds the ability to specify
the `PUPPET_AGENT_SHA` and `PUPPET_AGENT_SUITE_VERSION` environment variables,
which will then install puppet-agent from the development package repositories.