### PR TITLE
(maint) Update travis CI to use a modern ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ script: "bundle exec rspec spec"
 notifications:
   email: false
 rvm:
-  - 2.1.6
-  - 1.9.3
+  - 2.3.1
+  - 2.2.5


### PR DESCRIPTION
Previously Travis CI was failing due to Beaker-3.6.0 requiring ruby >= 2.2.5.
This commit modifies the ruby versions used in testing to the modern versions of
2.2.5 and 2.3.1.