### PR TITLE
(MODULES-7028) handle puppet_collection for windows

### DIFF
--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -108,10 +108,23 @@ module Beaker::PuppetInstallHelper
     ENV['PUPPET_INSTALL_VERSION'] || ENV['PUPPET_VERSION']
   end
 
+  def hosts_contains_windows_agent?(hosts)
+    hosts_with_role(hosts, 'agent').select { |host| host['platform'].match(/^windows/) }.size > 0
+  end
+
   def install_agent_on(hosts, collection, version)
     if ENV['PUPPET_AGENT_SHA'].nil?
-      opts = options.merge(puppet_collection: collection,
-                           version: version)
+      opts = if hosts_contains_windows_agent?(hosts)
+               if version && version.match(/5\.\d\.\d/)
+                 options.merge(version: version,
+                               puppet_collection: 'puppet5')
+               else
+                 options.merge(version: version)
+               end
+             else
+               options.merge(version: version,
+                             puppet_collection: collection)
+             end
       install_puppet_agent_on(hosts, opts)
     else
       opts = options.merge(puppet_collection: collection,


### PR DESCRIPTION
Installing the agent on Windows machines works a little differently than installing the agent on Posix. There are no 'collections', so Beaker is simply building a URL for the msi location. We only need to pass a collection to Beaker if we're installing the puppet 5 agent on Windows. This change adds a conditional to check whether we're installing Puppet 5 or not and sets the Beaker options accordingly. We still need to pass a collection for Posix in all cases, so there's some nested conditional action going on.