### PR TITLE
Redo collections. Use beaker's built-in code more.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.0]
+### Changed
+- Use `BEAKER_IS_PE` instead of `PUPPET_INSTALL_TYPE` to specify whether a run should be PE or agent.
+- Use `BEAKER_PUPPET_COLLECTION` instead of `PUPPET_INSTALL_TYPE` to specify puppet5, puppet6-nightly, etc. collections.
+- Use `BEAKER_PUPPET_AGENT_VERSION` instead of `PUPPET_INSTALL_VERSION`
+- Use `BEAKER_PUPPET_AGENT_SHA` instead of `PUPPET_AGENT_SHA`
+
+### Fixed
+- Beaker only cares about the SHA and no longer cares about `PUPPET_AGENT_SUITE_VERSION` so deprecating that variable. See (the beaker source)[https://github.com/puppetlabs/beaker-puppet/blob/63ea32a0d7caa8f261c533b020625de19569f971/lib/beaker-puppet/install_utils/foss_utils.rb#L1150-L1152]
+
 ## [0.8.0]
 ### Changed
 - Changed the default `PUPPET_INSTALL_TYPE` from "agent" (puppet 4) to "puppet5"

--- a/README.md
+++ b/README.md
@@ -4,22 +4,15 @@ This gem is simply an abstraction for the various ways that we install puppet fr
 
 ### `run_puppet_install_helper`
 
-The way to use this is to declare either `run_puppet_install_helper()` or `run_puppet_install_helper_on(hosts)` and set environment variables `PUPPET_INSTALL_VERSION` and/or `PUPPET_INSTALL_TYPE` in the following combinations to have puppet installed on the desired hosts:
+The way to use this is to declare either `run_puppet_install_helper()` or `run_puppet_install_helper_on(hosts)` and set environment variables `BEAKER_PUPPET_AGENT_VERSION` and/or `BEAKER_PUPPET_COLLECTION` in the following combinations to have puppet installed on the desired hosts. The nodeset should be configured with `type: pe` or `type: aio` to control the type of install.
 
-- `PUPPET_INSTALL_TYPE` is unset: if `type: pe` is set for the default node in the nodeset, it will us the PE install method. Otherwise it will only install an agent.
-- `PUPPET_INSTALL_TYPE=pe` will read `PUPPET_INSTALL_VERSION` and attempt to install that version of the PE tarball. If no version is set, then it uses the latest stable build.
-- `PUPPET_INSTALL_TYPE=agent` will read `PUPPET_INSTALL_VERSION` and install that version of puppet-agent (eg, `PUPPET_INSTALL_TYPE=agent PUPPET_INSTALL_VERSION=1.0.0`)
-- `PUPPET_INSTALL_TYPE=foss` will read `PUPPET_INSTALL_VERSION` and pass that on to beaker's [install_puppet_on](http://www.rubydoc.info/github/puppetlabs/beaker/Beaker%2FDSL%2FInstallUtils%2FFOSSUtils%3Ainstall_puppet_on)
-  - if a `master` role is defined, will install puppetserver on that node. Note that the corresponding puppet-agent dependency will be installed on that node rather than the specified `PUPPET_INSTALL_VERSION`.
+- `BEAKER_PUPPET_COLLECTION=<puppet collection>` will install the specified `BEAKER_PUPPET_AGENT_VERSION` from the specified collection. Valid values are `pc1`, `puppet5`, `puppet6-nightly` etc. This may change with time.
+- `BEAKER_PUPPET_AGENT_VERSION=<version>` to specify
+- `BEAKER_IS_PE=<yes or no>` may be used to force a nodeset to be PE or not, regardless of the nodeset `type` or absence thereof.
+- `BEAKER_PUPPET_AGENT_SHA=<sha>` may be used in order to use a development puppet-agent package.
+- `PUPPET_INSTALL_TYPE=foss` may be used to install foss puppet 3.x, but is deprecated and should not be used.
 
-The best way is explicitly set `PUPPET_INSTALL_TYPE` and `PUPPET_INSTALL_VERSION` to what you want. It'll probably do what you expect.
-
-#### Installing a puppet-agent package from a development repository
-
-In order to use a custom, or unreleased, puppet-agent package set the following environment variables"
-- `PUPPET_INSTALL_TYPE=agent`
-- `PUPPET_AGENT_SHA` is the longform commit SHA used when building the puppet-agent package, for example `PUPPET_AGENT_SHA=18d31fd5ed41abb276398201f84a4347e0fc7092`.  This is required to be set in order to use a development puppet-agent package
-- `PUPPET_AGENT_SUITE_VERSION` is the version of the puppet-agent package, for example `PUPPET_AGENT_SUITE_VERSION="1.8.2.350.g18d31fd`.  This is optional, and will default to `PUPPET_AGENT_SHA` if not set
+The best way is explicitly set `BEAKER_PUPPET_COLLECTION` and `BEAKER_PUPPET_AGENT_VERSION` to what you want. It'll probably do what you expect.
 
 ### `install_ca_certs`
 

--- a/beaker-puppet_install_helper.gemspec
+++ b/beaker-puppet_install_helper.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'beaker-puppet_install_helper'
-  s.version     = '0.8.0'
+  s.version     = '0.9.0'
   s.authors     = ['Puppetlabs']
   s.email       = ['hunter@puppet.com']
   s.homepage    = 'https://github.com/puppetlabs/beaker-puppet_install_helper'

--- a/spec/unit/beaker/puppet_install_helper_spec.rb
+++ b/spec/unit/beaker/puppet_install_helper_spec.rb
@@ -24,6 +24,7 @@ describe 'Beaker::PuppetInstallHelper' do
     allow(subject).to receive(:on)
     allow(subject).to receive(:fact_on)
     allow(subject).to receive(:agents).and_return(hosts)
+    allow(subject).to receive(:default).and_return(hosts[0])
   end
   after :each do
     ENV.delete('PUPPET_VERSION')
@@ -31,20 +32,23 @@ describe 'Beaker::PuppetInstallHelper' do
     ENV.delete('PUPPET_INSTALL_TYPE')
     ENV.delete('PUPPET_AGENT_SHA')
     ENV.delete('PUPPET_AGENT_SUITE_VERSION')
+    ENV.delete('BEAKER_IS_PE')
+    ENV.delete('BEAKER_PUPPET_COLLECTION')
+    ENV.delete('BEAKER_PUPPET_AGENT_VERSION')
+    ENV.delete('BEAKER_PUPPET_AGENT_SHA')
   end
   describe '#run_puppet_install_helper' do
     before :each do
       allow(subject).to receive(:hosts).and_return(hosts)
-      allow(subject).to receive(:default).and_return(hosts[0])
     end
     it 'calls run_puppet_install_helper_on on each host' do
-      expect(subject).to receive(:run_puppet_install_helper_on).with(hosts, 'puppet5', nil)
+      expect(subject).to receive(:run_puppet_install_helper_on).with(hosts, 'agent', nil)
       subject.run_puppet_install_helper
     end
-    %w(PUPPET_VERSION PUPPET_INSTALL_VERSION).each do |version_var|
+    %w(BEAKER_PUPPET_AGENT_VERSION PUPPET_VERSION PUPPET_INSTALL_VERSION).each do |version_var|
       it 'calls run_puppet_install_helper_on on each host with a version ' do
         ENV[version_var] = '4.1.0'
-        expect(subject).to receive(:run_puppet_install_helper_on).with(hosts, 'puppet5', '4.1.0')
+        expect(subject).to receive(:run_puppet_install_helper_on).with(hosts, 'agent', '4.1.0')
         subject.run_puppet_install_helper
       end
     end
@@ -55,7 +59,7 @@ describe 'Beaker::PuppetInstallHelper' do
         expect(subject).to receive(:default).and_return(hosts[0])
         expect(subject).to receive(:add_aio_defaults_on).with(hosts)
         expect(subject).to receive(:add_puppet_paths_on).with(hosts)
-        expect(subject).to receive(:install_puppet_agent_on).with(hosts, puppet_collection: 'puppet5', version: nil)
+        expect(subject).to receive(:install_puppet_agent_on).with(hosts, version: nil)
         subject.run_puppet_install_helper_on(hosts)
       end
       it 'windows 2003 node' do
@@ -73,64 +77,125 @@ describe 'Beaker::PuppetInstallHelper' do
         subject.run_puppet_install_helper_on(hosts)
       end
     end
-    context 'for foss' do
-      let :hosts do
-        foss_host = double(is_pe?: false)
-        foss_master = double(is_pe?: false)
-        allow(foss_host).to receive(:[]).with('distmoduledir').and_return('/dne')
-        allow(foss_host).to receive(:[]).with('platform').and_return('Debian')
-        allow(foss_host).to receive(:[]).with('pe_ver').and_return(nil)
-        allow(foss_host).to receive(:[]).with('roles').and_return(['agent'])
-        allow(foss_host).to receive(:puppet).and_return('hiera_config' => '/dne')
-        allow(foss_master).to receive(:[]).with('pe_ver').and_return(nil)
-        allow(foss_master).to receive(:[]=).with('distmoduledir', 'foo')
-        allow(foss_master).to receive(:[]).with('platform').and_return('Debian')
-        allow(foss_master).to receive(:[]).with('roles').and_return(['master'])
-        allow(foss_master).to receive(:get_ip).and_return('1.2.3.4')
-        allow(foss_master).to receive(:install_package).with('puppetserver')
-        allow(foss_master).to receive(:get_ip).and_return('1.2.3.4')
-        [foss_host, foss_master]
-      end
-      let :result do
-        Beaker::Result.new( nil, nil )
-      end
-      before :each do
-        allow(subject).to receive(:master).and_return(hosts[1])
-        allow(subject).to receive(:sign_certificate_for)
-        allow(subject).to receive(:puppet_agent)
-        allow(subject).to receive(:puppet).with('resource', 'service', 'puppetserver', 'ensure=running')
-        allow(subject).to receive(:puppet).with('resource', 'host', 'puppet', 'ensure=present', 'ip=1.2.3.4')
-        allow(subject).to receive(:puppet).with('agent', '--test')
-        allow(subject).to receive(:puppet).with('config', 'print', 'modulepath')
-        allow(subject).to receive(:on).and_return(result)
-        result.stdout = 'foo:bar'
-      end
-      it 'uses foss explicitly' do
-        ENV['PUPPET_INSTALL_TYPE'] = 'foss'
-        expect(subject).to receive(:install_puppetlabs_release_repo).with(hosts[1], 'pc1')
-        expect(subject).to receive(:install_puppet_on).with(hosts[0], version: nil, default_action: 'gem_install')
-        subject.run_puppet_install_helper_on(hosts)
-      end
-      %w(PUPPET_VERSION PUPPET_INSTALL_VERSION).each do |version_var|
-        it 'uses foss with a version' do
+    context 'for non-pe' do
+      context 'and foss type' do
+        let :hosts do
+          foss_host = double(is_pe?: false)
+          foss_master = double(is_pe?: false)
+          allow(foss_host).to receive(:[]).with('distmoduledir').and_return('/dne')
+          allow(foss_host).to receive(:[]).with('platform').and_return('Debian')
+          allow(foss_host).to receive(:[]).with('pe_ver').and_return(nil)
+          allow(foss_host).to receive(:[]).with('roles').and_return(['agent'])
+          allow(foss_host).to receive(:puppet).and_return('hiera_config' => '/dne')
+          allow(foss_master).to receive(:[]).with('pe_ver').and_return(nil)
+          allow(foss_master).to receive(:[]=).with('distmoduledir', 'foo')
+          allow(foss_master).to receive(:[]).with('platform').and_return('Debian')
+          allow(foss_master).to receive(:[]).with('roles').and_return(['master'])
+          allow(foss_master).to receive(:get_ip).and_return('1.2.3.4')
+          allow(foss_master).to receive(:install_package).with('puppetserver')
+          allow(foss_master).to receive(:get_ip).and_return('1.2.3.4')
+          [foss_host, foss_master]
+        end
+        let :result do
+          Beaker::Result.new( nil, nil )
+        end
+        before :each do
+          allow(subject).to receive(:master).and_return(hosts[1])
+          allow(subject).to receive(:sign_certificate_for)
+          allow(subject).to receive(:puppet_agent)
+          allow(subject).to receive(:puppet).with('resource', 'service', 'puppetserver', 'ensure=running')
+          allow(subject).to receive(:puppet).with('resource', 'host', 'puppet', 'ensure=present', 'ip=1.2.3.4')
+          allow(subject).to receive(:puppet).with('agent', '--test')
+          allow(subject).to receive(:puppet).with('config', 'print', 'modulepath')
+          allow(subject).to receive(:on).and_return(result)
+          result.stdout = 'foo:bar'
+        end
+        it 'uses foss explicitly' do
           ENV['PUPPET_INSTALL_TYPE'] = 'foss'
-          ENV[version_var] = '3.8.1'
           expect(subject).to receive(:install_puppetlabs_release_repo).with(hosts[1], 'pc1')
-          expect(subject).to receive(:install_puppet_on).with(hosts[0], version: '3.8.1', default_action: 'gem_install')
+          expect(subject).to receive(:install_puppet_on).with(hosts[0], version: nil, default_action: 'gem_install')
           subject.run_puppet_install_helper_on(hosts)
         end
-        it 'uses foss with a >4 version detects AIO' do
-          ENV['PUPPET_INSTALL_TYPE'] = 'foss'
-          ENV[version_var] = '4.1.0'
-          expect(subject).to receive(:install_puppetlabs_release_repo).with(hosts[1], 'pc1')
-          expect(subject).to receive(:install_puppet_on).with(hosts[0], version: '4.1.0', default_action: 'gem_install')
-          expect(subject).to receive(:add_aio_defaults_on).with(hosts)
-          expect(subject).to receive(:add_puppet_paths_on).with(hosts)
-          subject.run_puppet_install_helper_on(hosts)
+        %w(BEAKER_PUPPET_AGENT_VERSION PUPPET_VERSION PUPPET_INSTALL_VERSION).each do |version_var|
+          it 'uses foss with a version' do
+            ENV['PUPPET_INSTALL_TYPE'] = 'foss'
+            ENV[version_var] = '3.8.1'
+            expect(subject).to receive(:install_puppetlabs_release_repo).with(hosts[1], 'pc1')
+            expect(subject).to receive(:install_puppet_on).with(hosts[0], version: '3.8.1', default_action: 'gem_install')
+            subject.run_puppet_install_helper_on(hosts)
+          end
+          it 'uses foss with a 4.x version detects AIO' do
+            ENV['PUPPET_INSTALL_TYPE'] = 'foss'
+            ENV[version_var] = '4.1.0'
+            expect(subject).to receive(:install_puppetlabs_release_repo).with(hosts[1], 'pc1')
+            expect(subject).to receive(:install_puppet_on).with(hosts[0], version: '4.1.0', default_action: 'gem_install')
+            expect(subject).to receive(:add_aio_defaults_on).with(hosts)
+            expect(subject).to receive(:add_puppet_paths_on).with(hosts)
+            subject.run_puppet_install_helper_on(hosts)
+          end
+          it 'uses pc1 with a 5.x version; this fails' do
+            ENV['PUPPET_INSTALL_TYPE'] = 'foss'
+            ENV[version_var] = '5.1.0'
+            expect(subject).to receive(:install_puppetlabs_release_repo).with(hosts[1], 'pc1')
+            expect(subject).to receive(:install_puppet_on).with(hosts[0], version: '5.1.0', default_action: 'gem_install')
+            expect(subject).to receive(:add_aio_defaults_on).with(hosts)
+            expect(subject).to receive(:add_puppet_paths_on).with(hosts)
+            subject.run_puppet_install_helper_on(hosts)
+          end
+        end
+      end
+      context 'for agent type' do
+        context 'with no collection' do
+          it 'uses agent by default for non-pe hosts' do
+            expect(subject).to receive(:install_puppet_agent_on).with(hosts, version: nil)
+            expect(subject).to receive(:add_aio_defaults_on).with(hosts)
+            expect(subject).to receive(:add_puppet_paths_on).with(hosts)
+            subject.run_puppet_install_helper_on(hosts)
+          end
+          it 'uses agent explicitly' do
+            ENV['PUPPET_INSTALL_TYPE'] = 'agent'
+            expect(subject).to receive(:install_puppet_agent_on).with(hosts, version: nil)
+            expect(subject).to receive(:add_aio_defaults_on).with(hosts)
+            expect(subject).to receive(:add_puppet_paths_on).with(hosts)
+            subject.run_puppet_install_helper_on(hosts)
+          end
+        end
+        ['puppet5', 'puppet6-nightly'].each do |collection|
+          context "with #{collection} collection" do
+            it "installs puppet-agent from #{collection} repo" do
+              ENV['BEAKER_PUPPET_COLLECTION'] = collection
+              expect(subject).to receive(:install_puppet_agent_on).with(hosts, version: nil)
+              expect(subject).to receive(:add_aio_defaults_on).with(hosts)
+              expect(subject).to receive(:add_puppet_paths_on).with(hosts)
+              subject.run_puppet_install_helper_on(hosts)
+            end
+          end
+        end
+        context 'with a specific development sha' do
+          it 'uses a development repo' do
+            ENV['BEAKER_PUPPET_AGENT_SHA'] = '0ed2bbc918326263da9d97d0361a9e9303b52938'
+            expect(subject).to receive(:install_puppet_agent_dev_repo_on).with(hosts, puppet_agent_sha: '0ed2bbc918326263da9d97d0361a9e9303b52938', puppet_agent_version: '0ed2bbc918326263da9d97d0361a9e9303b52938')
+            expect(subject).to receive(:add_aio_defaults_on).with(hosts)
+            expect(subject).to receive(:add_puppet_paths_on).with(hosts)
+            subject.run_puppet_install_helper_on(hosts)
+          end
+          it 'uses a development repo with suite version and sha' do
+            ENV['BEAKER_PUPPET_AGENT_SHA'] = '0ed2bbc918326263da9d97d0361a9e9303b52938'
+            ENV['PUPPET_AGENT_SUITE_VERSION'] = '5.5.0.152.g0ed2bbc'
+            expect(subject).to receive(:install_puppet_agent_dev_repo_on).with(hosts, puppet_agent_sha: '0ed2bbc918326263da9d97d0361a9e9303b52938', puppet_agent_version: '5.5.0.152.g0ed2bbc')
+            expect(subject).to receive(:add_aio_defaults_on).with(hosts)
+            expect(subject).to receive(:add_puppet_paths_on).with(hosts)
+            subject.run_puppet_install_helper_on(hosts)
+          end
         end
       end
     end
     context 'for PE' do
+      it 'uses PE when default is a pe host' do
+        expect(subject).to receive(:default).and_return(hosts[1])
+        expect(subject).to receive(:install_pe_on).with(hosts, 'pe_ver' => nil)
+        subject.run_puppet_install_helper_on(hosts)
+      end
       it 'uses PE explicitly' do
         ENV['PUPPET_INSTALL_TYPE'] = 'pe'
         expect(subject).to receive(:install_pe_on).with(hosts, 'pe_ver' => nil)
@@ -150,42 +215,6 @@ describe 'Beaker::PuppetInstallHelper' do
         expect(subject).to receive(:install_pe_on).with(hosts, 'pe_ver' => '3.8.1')
         expect(subject).to receive(:create_cert_on_host).exactly(3).times
         expect(subject).to receive(:add_solaris_cert).exactly(3).times
-        subject.run_puppet_install_helper_on(hosts)
-      end
-    end
-    context 'for puppet-agent' do
-      it 'uses agent explicitly' do
-        ENV['PUPPET_INSTALL_TYPE'] = 'puppet5'
-        expect(subject).to receive(:install_puppet_agent_on).with(hosts, puppet_collection: 'puppet5', version: nil)
-        expect(subject).to receive(:add_aio_defaults_on).with(hosts)
-        expect(subject).to receive(:add_puppet_paths_on).with(hosts)
-        subject.run_puppet_install_helper_on(hosts)
-      end
-      it 'uses foss with a version' do
-        ENV['PUPPET_INSTALL_TYPE'] = 'puppet5'
-        ENV['PUPPET_INSTALL_VERSION'] = '5.5.0'
-        expect(subject).to receive(:install_puppet_agent_on).with(hosts, puppet_collection: "puppet5", version: '5.5.0')
-        expect(subject).to receive(:add_aio_defaults_on).with(hosts)
-        expect(subject).to receive(:add_puppet_paths_on).with(hosts)
-        subject.run_puppet_install_helper_on(hosts)
-      end
-    end
-    context 'for puppet-agent development repo' do
-      before :each do
-        ENV['PUPPET_INSTALL_TYPE'] = 'puppet6-nightly'
-        ENV['PUPPET_AGENT_SHA'] = 'abc123'
-      end
-      it 'uses a development repo' do
-        expect(subject).to receive(:install_puppet_agent_dev_repo_on).with(hosts, puppet_collection: 'puppet6-nightly', puppet_agent_sha: 'abc123', puppet_agent_version: 'abc123')
-        expect(subject).to receive(:add_aio_defaults_on).with(hosts)
-        expect(subject).to receive(:add_puppet_paths_on).with(hosts)
-        subject.run_puppet_install_helper_on(hosts)
-      end
-      it 'uses a development repo with suite version' do
-        ENV['PUPPET_AGENT_SUITE_VERSION'] = '1.0.0.0.gabc123'
-        expect(subject).to receive(:install_puppet_agent_dev_repo_on).with(hosts, puppet_collection: 'puppet6-nightly', puppet_agent_sha: 'abc123', puppet_agent_version: '1.0.0.0.gabc123')
-        expect(subject).to receive(:add_aio_defaults_on).with(hosts)
-        expect(subject).to receive(:add_puppet_paths_on).with(hosts)
         subject.run_puppet_install_helper_on(hosts)
       end
     end


### PR DESCRIPTION
The variable `PUPPET_INSTALL_TYPE` was originally introduced to control
selecting the PE/foss installation code, and later was changed to
allow the puppet-agent install code. It was incorrectly updated in 0.8.0
to also control collections however beaker already controls collections
via `BEAKER_PUPPET_COLLECTION` so this was not need (and broke beaker's
usage.)

`PUPPET_INSTALL_TYPE` still can be used to install 3.x foss instead of
puppet-agent, but that is deprecated.

Other variables in beaker also cover the functionality provided by some
in BPIH.