### PR TITLE
(maint) Point windows at the nightly url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.3]
+### Fixed
+- Windows needs to use nightlies.puppet.com for nightly builds because the nightlies are not published to downloads.puppet.com
+
 ## [0.9.2]
 ### Fixed
 - Fix debian nightly collection installation.
@@ -69,6 +73,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Add solaris for installing CA certs as well.
 
+[0.9.3]: https://github.com/puppetlabs/beaker-puppet_install_helper/compare/0.9.2...0.9.3
 [0.9.2]: https://github.com/puppetlabs/beaker-puppet_install_helper/compare/0.9.1...0.9.2
 [0.9.1]: https://github.com/puppetlabs/beaker-puppet_install_helper/compare/0.9.0...0.9.1
 [0.9.0]: https://github.com/puppetlabs/beaker-puppet_install_helper/compare/0.8.0...0.9.0

--- a/beaker-puppet_install_helper.gemspec
+++ b/beaker-puppet_install_helper.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'beaker-puppet_install_helper'
-  s.version     = '0.9.2'
+  s.version     = '0.9.3'
   s.authors     = ['Puppetlabs']
   s.email       = ['hunter@puppet.com']
   s.homepage    = 'https://github.com/puppetlabs/beaker-puppet_install_helper'

--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -83,9 +83,13 @@ module Beaker::PuppetInstallHelper
         end
       end
     when 'agent'
-      if find_agent_sha.nil?
+      if ENV['BEAKER_PUPPET_COLLECTION'] =~ /-nightly$/
         # Workaround for RE-10734
-        options[:release_apt_repo_url] = "http://apt.puppetlabs.com/#{ENV['BEAKER_PUPPET_COLLECTION']}" if ENV['BEAKER_PUPPET_COLLECTION'] =~ /-nightly$/
+        options[:release_apt_repo_url] = "http://apt.puppetlabs.com/#{ENV['BEAKER_PUPPET_COLLECTION']}"
+        options[:win_download_url] = 'http://nightlies.puppet.com/downloads/windows'
+        options[:mac_download_url] = 'http://nightlies.puppet.com/downloads/mac'
+      end
+      if find_agent_sha.nil?
         install_puppet_agent_on(hosts, options.merge(version: version))
       else
         opts = options.merge(puppet_agent_sha: find_agent_sha,

--- a/spec/unit/beaker/puppet_install_helper_spec.rb
+++ b/spec/unit/beaker/puppet_install_helper_spec.rb
@@ -166,7 +166,12 @@ describe 'Beaker::PuppetInstallHelper' do
             it "installs puppet-agent from #{collection} repo" do
               ENV['BEAKER_PUPPET_COLLECTION'] = collection
               if collection =~ /-nightly$/
-                expect(subject).to receive(:install_puppet_agent_on).with(hosts, release_apt_repo_url: "http://apt.puppetlabs.com/puppet6-nightly", version: nil)
+                expect(subject).to receive(:install_puppet_agent_on).with(
+                  hosts,
+                  release_apt_repo_url: "http://apt.puppetlabs.com/puppet6-nightly",
+                  win_download_url: "http://nightlies.puppet.com/downloads/windows",
+                  mac_download_url: "http://nightlies.puppet.com/downloads/mac",
+                  version: nil)
               else
                 expect(subject).to receive(:install_puppet_agent_on).with(hosts, version: nil)
               end


### PR DESCRIPTION
Apt/yum can pull the release repos from yum.puppet.com and
apt.puppet.com to be pointed at the nightlies.puppet.com package
directories, but since windows doesn't have any repository management it
has to be pointed directly at the URL.