### PR TITLE
(maint) Install dev packages using newer utils

### DIFF
--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -89,12 +89,14 @@ module Beaker::PuppetInstallHelper
         options[:win_download_url] = 'http://nightlies.puppet.com/downloads/windows'
         options[:mac_download_url] = 'http://nightlies.puppet.com/downloads/mac'
       end
-      if find_agent_sha.nil?
+
+      agent_sha = find_agent_sha
+      if agent_sha.nil?
         install_puppet_agent_on(hosts, options.merge(version: version))
       else
-        opts = options.merge(puppet_agent_sha: find_agent_sha,
-                             puppet_agent_version: ENV['PUPPET_AGENT_SUITE_VERSION'] || find_agent_sha)
-        install_puppet_agent_dev_repo_on(hosts, opts)
+        # If we have a development sha, assume we're testing internally
+        dev_builds_url = ENV['DEV_BUILDS_URL'] || 'http://builds.delivery.puppetlabs.net'
+        install_from_build_data_url('puppet-agent', "#{dev_builds_url}/puppet-agent/#{agent_sha}/artifacts/#{agent_sha}.yaml", hosts)
       end
 
       # XXX install_puppet_agent_on() will only add_aio_defaults_on when the

--- a/spec/unit/beaker/puppet_install_helper_spec.rb
+++ b/spec/unit/beaker/puppet_install_helper_spec.rb
@@ -182,17 +182,21 @@ describe 'Beaker::PuppetInstallHelper' do
           end
         end
         context 'with a specific development sha' do
+          let (:sha) { '0ed2bbc918326263da9d97d0361a9e9303b52938' }
+          let (:dev_builds_url) { 'http://builds.delivery.puppetlabs.net' }
+          let (:agent_url) { "#{dev_builds_url}/puppet-agent/#{sha}/artifacts/#{sha}.yaml" }
+
           it 'uses a development repo' do
-            ENV['BEAKER_PUPPET_AGENT_SHA'] = '0ed2bbc918326263da9d97d0361a9e9303b52938'
-            expect(subject).to receive(:install_puppet_agent_dev_repo_on).with(hosts, puppet_agent_sha: '0ed2bbc918326263da9d97d0361a9e9303b52938', puppet_agent_version: '0ed2bbc918326263da9d97d0361a9e9303b52938')
+            ENV['BEAKER_PUPPET_AGENT_SHA'] = sha
+            allow(subject).to receive(:install_from_build_data_url).with('puppet-agent', agent_url, hosts).and_return true
             expect(subject).to receive(:add_aio_defaults_on).with(hosts)
             expect(subject).to receive(:add_puppet_paths_on).with(hosts)
             subject.run_puppet_install_helper_on(hosts)
           end
           it 'uses a development repo with suite version and sha' do
-            ENV['BEAKER_PUPPET_AGENT_SHA'] = '0ed2bbc918326263da9d97d0361a9e9303b52938'
+            ENV['BEAKER_PUPPET_AGENT_SHA'] = sha
             ENV['PUPPET_AGENT_SUITE_VERSION'] = '5.5.0.152.g0ed2bbc'
-            expect(subject).to receive(:install_puppet_agent_dev_repo_on).with(hosts, puppet_agent_sha: '0ed2bbc918326263da9d97d0361a9e9303b52938', puppet_agent_version: '5.5.0.152.g0ed2bbc')
+            allow(subject).to receive(:install_from_build_data_url).with('puppet-agent', agent_url, hosts).and_return true
             expect(subject).to receive(:add_aio_defaults_on).with(hosts)
             expect(subject).to receive(:add_puppet_paths_on).with(hosts)
             subject.run_puppet_install_helper_on(hosts)


### PR DESCRIPTION
This commit updates how we install packages when given a sha. We assume
that if you're not hitting 'latest' or a specific version, you want to
install from our development repos, which are internal only. This
behavior is triggered when a user sets either `BEAKER_PUPPET_AGENT_SHA`
or `PUPPET_AGENT_SHA`. Even if these are versions (rather than shas),
you will still be able to install packages as long as they are present
on builds.delivery.puppetlabs.net.