### PR TITLE
(maint) If agent_sha is an empty string, use public repo

### DIFF
--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -91,7 +91,7 @@ module Beaker::PuppetInstallHelper
       end
 
       agent_sha = find_agent_sha
-      if agent_sha.nil?
+      if agent_sha.nil? || agent_sha.empty?
         install_puppet_agent_on(hosts, options.merge(version: version))
       else
         # If we have a development sha, assume we're testing internally


### PR DESCRIPTION
If we have an environment variable for the agent sha that is set to an
empty string, we'll still attempt to fetch from
builds.delivery.puppetlabs.net. For a more robust system, we should
check if nil or empty to determine how to try to fetch our package.