### PR TITLE
(wip) prep for puppetserver 6

### DIFF
--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -48,8 +48,9 @@ module Beaker::PuppetInstallHelper
       if hosts_with_role(hosts, 'master').length>0 then
         # TODO Make the puppetserver code work with puppet5/puppet6
         # install puppetserver
-        install_puppetlabs_release_repo( master, 'pc1' )
+        install_puppetlabs_release_repo( master, ENV['BEAKER_PUPPET_COLLECTION'] || 'pc1')
         master.install_package('puppetserver')
+        on(master, 'puppetserver ca generate')
         on(master, puppet('resource', 'service', 'puppetserver', 'ensure=running'))
         agents.each do |agent|
           on(agent, puppet('resource', 'host', 'puppet', 'ensure=present', "ip=#{master.get_ip}"))


### PR DESCRIPTION
Stolen directly from https://github.com/puppetlabs/beaker-puppet/pull/65

---

In Puppet 6 we're hoping to move pki management from puppet cert and several places where it was implicitly bootstrapped to a single revamped cli tool. These are, superficially, the changes that seem like they should be made.

However, I have yet to incorporate these changes into a consumer project like Puppet, so I don't know for sure.

I assume consumers will also want some kind of toggle of for some magic detection of which Puppet version we're operating against and doing the version appropriate thing.

Would love folks' thoughts on that last point.


