### PR TITLE
(MAINT) change beaker-puppet to beaker-pe

### DIFF
--- a/beaker-puppet_install_helper.gemspec
+++ b/beaker-puppet_install_helper.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker', '>= 4.0'
-  s.add_runtime_dependency 'beaker-puppet', '>= 1.6.0'
+  s.add_runtime_dependency 'beaker', '~> 4.0'
+  s.add_runtime_dependency 'beaker-pe', '~> 2.0'
 end

--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -1,5 +1,5 @@
 require 'beaker'
-require 'beaker-puppet'
+require 'beaker-pe'
 require 'beaker/ca_cert_helper'
 
 module Beaker::PuppetInstallHelper


### PR DESCRIPTION
We are seeing jobs fail trying to install PE because
this gem includes beaker-puppet rather than beaker-pe.
Since beaker-pe depends on beaker-puppet, we can swap
out the reference & get both library's helper methods