### PR TITLE
(MAINT) update version structure for CI releases

### DIFF
--- a/beaker-puppet_install_helper.gemspec
+++ b/beaker-puppet_install_helper.gemspec
@@ -1,6 +1,10 @@
+# -*- encoding: utf-8 -*-
+$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+require 'beaker-puppet_install_helper/version'
+
 Gem::Specification.new do |s|
   s.name        = 'beaker-puppet_install_helper'
-  s.version     = '0.9.4'
+  s.version     = Beaker::PuppetInstallHelper::VERSION
   s.authors     = ['Puppetlabs']
   s.email       = ['hunter@puppet.com']
   s.homepage    = 'https://github.com/puppetlabs/beaker-puppet_install_helper'

--- a/lib/beaker-puppet_install_helper/version.rb
+++ b/lib/beaker-puppet_install_helper/version.rb
@@ -1,0 +1,5 @@
+module Beaker
+  module PuppetInstallHelper
+    VERSION = "0.9.5"
+  end
+end


### PR DESCRIPTION
In order to easily release new versions of this gem from
our current gem release jobs, this project needs to conform
to our version standard for gems. This change makes that
happen.

Notice that there's also a version update here. This is accounting for
a versioning mistake I made when tagging. Having this automated
will ensure these mistakes can't happen in the future.