### PR TITLE
(MAINT) fix inclusion mechanism

### DIFF
--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -1,4 +1,5 @@
 require 'beaker'
+require 'beaker-puppet'
 require 'beaker-pe'
 require 'beaker/ca_cert_helper'
 
@@ -129,3 +130,5 @@ module Beaker::PuppetInstallHelper
 end
 
 include Beaker::PuppetInstallHelper
+include BeakerPuppet
+include Beaker::DSL::PE


### PR DESCRIPTION
Before, we found that including the libraries via
require statements doesnt make those methods available
to this code. The methods need to be included as well