### PR TITLE
(RE-12325) Changes to public release package links

### DIFF
--- a/lib/beaker/puppet_install_helper.rb
+++ b/lib/beaker/puppet_install_helper.rb
@@ -88,7 +88,7 @@ module Beaker::PuppetInstallHelper
     when 'agent'
       if ENV['BEAKER_PUPPET_COLLECTION'] =~ /-nightly$/
         # Workaround for RE-10734
-        options[:release_apt_repo_url] = "http://apt.puppetlabs.com/#{ENV['BEAKER_PUPPET_COLLECTION']}"
+        options[:release_apt_repo_url] = "http://nightlies.puppet.com/apt"
         options[:win_download_url] = 'http://nightlies.puppet.com/downloads/windows'
         options[:mac_download_url] = 'http://nightlies.puppet.com/downloads/mac'
       end


### PR DESCRIPTION
The apt nightlies will be moved to nightlies.puppet.com on May 14 permanently and removed from the current apt repo.